### PR TITLE
Adding 2 failover strategies: hard reset and graceful failover

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -33,6 +33,8 @@ spec:
         - -zap-log-level=info
         image: quay.io/opstree/redis-operator:v0.9.0
         imagePullPolicy: Always
+        ports:
+          - containerPort: 8090
         name: manager
         securityContext:
           allowPrivilegeEscalation: false

--- a/controllers/rediscluster_controller.go
+++ b/controllers/rediscluster_controller.go
@@ -146,6 +146,9 @@ func (r *RedisClusterReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RedisClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	go (&k8sutils.RedisClusterCmdHandler{
+		Client: r.Client,
+	}).StartCmdServer()
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&redisv1beta1.RedisCluster{}).
 		Complete(r)

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,7 @@ github.com/googleapis/gnostic v0.5.1/go.mod h1:6U4PtQXGIEt/Z3h5MAT7FNofLnw9vXk2c
 github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
 github.com/googleapis/gnostic v0.5.5/go.mod h1:7+EbHbldMins07ALC74bsA81Ovc97DwqyJO1AENw9kA=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=

--- a/k8sutils/redis-cluster-cmd-handler.go
+++ b/k8sutils/redis-cluster-cmd-handler.go
@@ -1,0 +1,81 @@
+package k8sutils
+
+import (
+	"context"
+	"github.com/gorilla/mux"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
+	"net/http"
+	redisv1beta1 "redis-operator/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func recoverCluster(ns string, cn string, cl client.Client) error {
+	logger := generateRedisManagerLogger(ns, cn)
+	cr := &redisv1beta1.RedisCluster{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: cn, Namespace: ns}, cr); err != nil {
+		logger.Error(err, "CRD fetch error")
+		return err
+	}
+	err := ExecuteGracefulFailOverOperation(cr)
+	if err != nil {
+		logger.Error(err, "graceful failover error")
+	}
+	return err
+}
+
+func forceRecoverCluster(ns string, cn string, cl client.Client) error {
+	logger := generateRedisManagerLogger(ns, cn)
+	cr := &redisv1beta1.RedisCluster{}
+	if err := cl.Get(context.TODO(), types.NamespacedName{Name: cn, Namespace: ns}, cr); err != nil {
+		logger.Error(err, "CRD fetch error")
+		return err
+	}
+	err := ExecuteFailoverOperation(cr)
+	if err != nil {
+		logger.Error(err, "graceful failover error")
+	}
+	return err
+}
+
+type RedisClusterCmdHandler struct {
+	client.Client
+}
+
+func send(w http.ResponseWriter, res map[string]string, status int) {
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(res)
+}
+
+func sendError(w http.ResponseWriter, res error, status int) {
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(res)
+}
+func (h *RedisClusterCmdHandler) resetClusterHandler(w http.ResponseWriter, r *http.Request) {
+	ns := mux.Vars(r)["namespace"]
+	cn := mux.Vars(r)["clusterName"]
+	err := recoverCluster(ns, cn, h.Client)
+	if err != nil {
+		sendError(w, err, http.StatusInternalServerError)
+		return
+	}
+	send(w, map[string]string{"status": "OK"}, http.StatusOK)
+}
+
+func (h *RedisClusterCmdHandler) forceResetClusterHandler(w http.ResponseWriter, r *http.Request) {
+	ns := mux.Vars(r)["namespace"]
+	cn := mux.Vars(r)["clusterName"]
+	err := forceRecoverCluster(ns, cn, h.Client)
+	if err != nil {
+		sendError(w, err, http.StatusInternalServerError)
+		return
+	}
+	send(w, map[string]string{"status": "OK"}, http.StatusOK)
+}
+
+func (h *RedisClusterCmdHandler) StartCmdServer() {
+	router := mux.NewRouter().StrictSlash(true)
+	router.HandleFunc("/cluster/{namespace}/{clusterName}/reset", h.resetClusterHandler).Methods("POST")
+	router.HandleFunc("/cluster/{namespace}/{clusterName}/force-reset", h.forceResetClusterHandler).Methods("POST")
+	http.ListenAndServe(":8090", router)
+}

--- a/k8sutils/redis.go
+++ b/k8sutils/redis.go
@@ -172,6 +172,92 @@ func ExecuteFailoverOperation(cr *redisv1beta1.RedisCluster) error {
 	return nil
 }
 
+func ExecuteGracefulFailOverOperation(cr *redisv1beta1.RedisCluster) error {
+	logger := generateRedisManagerLogger(cr.Namespace, cr.ObjectMeta.Name)
+	err := executeClusterForget(cr, "leader")
+	if err != nil {
+		return err
+	}
+	logger.Info("Leaders forgotten")
+	err = executeClusterForget(cr, "follower")
+	if err != nil {
+		return err
+	}
+	logger.Info("Followers forgotten")
+	executeMasterClusterCreation(cr)
+	executeFailoverCommand(cr, "follower")
+	return nil
+}
+
+func executeMasterClusterCreation(cr *redisv1beta1.RedisCluster) {
+	logger := generateRedisManagerLogger(cr.Namespace, cr.ObjectMeta.Name)
+	count := cr.Spec.GetReplicaCounts("leader")
+	podName := fmt.Sprintf("%s-%s-", cr.ObjectMeta.Name, "leader")
+	client := configureRedisClient(cr, podName+strconv.Itoa(0))
+	for podCount := 1; podCount <= int(count)-1; podCount++ {
+		completePodName := podName + strconv.Itoa(podCount)
+		ip := getRedisServerIP(RedisDetails{
+			PodName:   completePodName,
+			Namespace: cr.Namespace,
+		})
+		cmd := redis.NewStringCmd("cluster", "meet", ip, "6379")
+		err := client.Process(cmd)
+		logger.Info("MEET EXECUTED", "pod", completePodName, "ip", ip, "err", err)
+	}
+}
+
+func executeClusterForget(cr *redisv1beta1.RedisCluster, role string) error {
+	logger := generateRedisManagerLogger(cr.Namespace, cr.ObjectMeta.Name)
+	count := cr.Spec.GetReplicaCounts(role)
+	podName := fmt.Sprintf("%s-%s-", cr.ObjectMeta.Name, role)
+	for podCount := 0; podCount <= int(count)-1; podCount++ {
+		client := configureRedisClient(cr, podName+strconv.Itoa(podCount))
+		cmd := redis.NewStringCmd("cluster", "nodes")
+		err := client.Process(cmd)
+		if err != nil {
+			return err
+		}
+		nodesResult, err := cmd.Result()
+		if err != nil {
+			return err
+		}
+		if strings.Contains(nodesResult, "myself,slave") {
+			logger.Info("Slave, Disconnecting from master")
+			cmd := redis.NewStringCmd("CLUSTER", "FAILOVER", "TAKEOVER")
+			err = client.Process(cmd)
+			if err != nil {
+				return err
+			}
+		}
+		nodeIds, err := getNodeIds(nodesResult)
+		if err != nil {
+			return err
+		}
+		for nodeCount := 0; nodeCount <= int(len(nodeIds))-1; nodeCount++ {
+			logger.Info("FORGETTING NODE", "podName", podName, "podCount", podCount, "nodeId", nodeIds[nodeCount])
+			cmd := redis.NewStringCmd("CLUSTER", "FORGET", nodeIds[nodeCount])
+			client.Process(cmd)
+		}
+		logger.Info("FORGETTING ALL NODES", "podName", podName, "podCount", podCount)
+	}
+	return nil
+}
+
+func getNodeIds(nodesResult string) ([]string, error) {
+	csvOutput := csv.NewReader(strings.NewReader(nodesResult))
+	csvOutput.Comma = ' '
+	csvOutput.FieldsPerRecord = -1
+	csvOutputRecords, err := csvOutput.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	var nodeIds []string
+	for i := 0; i < len(csvOutputRecords); i++ {
+		nodeIds = append(nodeIds, csvOutputRecords[i][0])
+	}
+	return nodeIds, nil
+}
+
 // executeFailoverCommand will execute failover command
 func executeFailoverCommand(cr *redisv1beta1.RedisCluster, role string) error {
 	logger := generateRedisManagerLogger(cr.Namespace, cr.ObjectMeta.Name)

--- a/k8sutils/statefulset.go
+++ b/k8sutils/statefulset.go
@@ -345,6 +345,18 @@ func getVolumeMount(name string, persistenceEnabled *bool, externalConfig *strin
 
 // getProbeInfo generate probe for Redis StatefulSet
 func getProbeInfo(probe *redisv1beta1.Probe) *corev1.Probe {
+	if probe == nil {
+		return &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{
+						"bash",
+						"/usr/bin/healthcheck.sh",
+					},
+				},
+			},
+		}
+	}
 	return &corev1.Probe{
 		InitialDelaySeconds: probe.InitialDelaySeconds,
 		PeriodSeconds:       probe.PeriodSeconds,

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ package main
 import (
 	"flag"
 	"os"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"


### PR DESCRIPTION
# Hard reset

This strategy is simple and will always succeed. Steps
1. Flush all the data
2. Reset cluster nodes. Note: Flush is required because cluster reset needs an empty node in redis.
3. Wait for 10 seconds for redis operator to be invoked. redis operator will automatically create a fresh cluster.

# Graceful failover

This strategy contains more steps. 
1. Connect to all the masters and run `CLUSTER FORGET` against all the other nodes in redis cluster
2. Connect to all the slaves and make it MASTER and now run `CLUSTER FORGET` against all nodes. This is required because we cannot run `CLUSTER FORGET` on a slave against its MASTER. That's why converting the SLAVE to MASTER
3. MEET all the masters against `leader-0`
4. Wait for 10 seconds. The redis operator will automatically add the slaves to the cluster.

In both the strategies **there will be a downtime**. In the first strategy there will be dataloss. These two workflows should be last resort. 